### PR TITLE
Update run-avrdude to add Arduino Mega 1280 support

### DIFF
--- a/build-deb/nuage-bridge/debian/usr/bin/run-avrdude
+++ b/build-deb/nuage-bridge/debian/usr/bin/run-avrdude
@@ -47,6 +47,11 @@ elif  grep '^board=Teensy36' /etc/nuage/nuage.cfg  ; then
 	/usr/local/bin/teensy_loader_cli -s -mmcu=mk66fx1m0 /tmp/sketch.hex
 elif  grep '^board=TeensyLC' /etc/nuage/nuage.cfg  ; then
 	/usr/local/bin/teensy_loader_cli -s -mmcu=mkl26z64 /tmp/sketch.hex
+elif  grep '^board=m1280' /etc/nuage/nuage.cfg  ; then
+	/usr/bin/avrdude-autoreset -C/etc/avrdude.conf -v \
+		-pm1280 -carduino \
+		-P/dev/${SERIALDEV} -b${BAUDRATE} \
+		-D -Uflash:w:/tmp/sketch.hex:i  	
 else
 	/usr/bin/avrdude-autoreset -C/etc/avrdude.conf -v \
 		-patmega328p -carduino \


### PR DESCRIPTION
Added Arduino Mega 1280 as a possible board.
Use with «board=m1280» in /etc/nuage/nuage.cfg

PS@Mattias: Bei einem frisch aufgestarteten System erhalte ich vom Arduino IDE her jedes Mal ein «Warning: Unit file of serial-getty@ttyAMA0.service changed on disk, 'systemctl daemon-reload' recommended.»